### PR TITLE
Fix auto-bump issue.

### DIFF
--- a/.github/workflows/build-publish-pypi-test.yml
+++ b/.github/workflows/build-publish-pypi-test.yml
@@ -18,7 +18,7 @@ jobs:
       with:
           persist-credentials: false
     - name: Get Current Version
-      run: echo -n "current_version=$(grep "version" setup.cfg | cut -d '=' -f2 | tr -d ' \t\n')" >> $GITHUB_ENV
+      run: echo -n "current_version=$(grep "version" setup.cfg | cut -d '=' -f2 | tr -d ' \t\n\r')" >> $GITHUB_ENV
     - name: Auto Bump Package Version
       uses: FragileTech/bump-version@main
       with:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = edgepi-rpc-client
-version = 0.0.1
+version = 0.0.4
 author = Josiah Kievit, Isaac James
 author_email = jkievit@osensa.com, ijames@osensa.com
 description = Client for EdgePi RPC Server


### PR DESCRIPTION
Fix for issue auto-bumping in build workflow. Changed the parsing of the `current_version` to take into account stray return characters.

Previously, auto-bump set current version `env.current_version` as `0.0.30` instead of `0.0.3` which made it unable to retrieve the variable from the setup.cfg file. This error likely came from the version parsing appending a character from the next version number onto the end of the current version.

The fix works on this branch.