### PR TITLE
Remove [bumpversion] section.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bumpversion]
-current_version = 0.0.3
-
 [metadata]
 name = edgepi-rpc-client
 version = 0.0.3


### PR DESCRIPTION
This PR fixes the auto-bump issue. The problem is that currently, the `[bumpversion]` section is still in the setup.cfg file of the staging branch. On push to staging, this was causing an error in which bump-version read both the `current_version` field of the `[bumpversion]` section as well as the `version` field of the `[metadata]` section in setup.cfg and concatenated them together as the version, e.g. `[bumpversion]0.0.30.0.3`.

To fix this, I need to push to a branch off the staging branch. In this branch, I can remove the `[bumpversion]` section. Note that this section isn't in the dev branch. Since setup.cfg is included in the `paths-ignore` of the workflow, the workflow won't be triggered.

I tested whether this reasoning is true by adding the `[bumpversion]` section to setup.cfg in the feature branch that previously worked and, as expected, I got the same error that staging currently has.