### PR TITLE
Add subpackages to build.

### DIFF
--- a/.github/workflows/python-integration-test.yml
+++ b/.github/workflows/python-integration-test.yml
@@ -1,9 +1,8 @@
 name: Python Integration Test
 
-on:
-  push:
-    branches:
-        - todo # enable this workflow once the issue with installing the server is resolved
+on: {} # TODO: enable this workflow once the issue with installing the server is resolved.
+#   push:
+#     branches:
 #       - dev
 #       - staging
 #       - main

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,15 @@ classifiers =
 	Operating System :: OS Independent
 
 [options]
-packages = edgepi_rpc_client
+packages =
+	edgepi_rpc_client,
+	edgepi_rpc_client.adc,
+	edgepi_rpc_client.dac,
+	edgepi_rpc_client.din,
+	edgepi_rpc_client.dout,
+	edgepi_rpc_client.led,
+	edgepi_rpc_client.relay,
+	edgepi_rpc_client.tc
 install_requires = 
 	protobuf>=3.20.3
 	edgepi-rpc-protobuf>=1.0.15


### PR DESCRIPTION
Previously, only the `edgepi_rpc_client` module was included in the build. This caused an error when trying to import submodules located under `edgepi_rpc_client` from the rpc-server when installing the client. I added these submodules in the build to allow the server to properly install the client.