### PR TITLE
Update setup.cfg

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 protobuf==3.20.3
-python-periphery==2.4.1
 pyzmq==25.1.0
-edgepi-python-sdk==1.2.8
+edgepi-python-sdk==1.2.13
 edgepi-rpc-protobuf==1.0.15

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,18 +12,14 @@ classifiers =
 	Operating System :: OS Independent
 
 [options]
-packages =
-	edgepi_rpc_client
-	edgepi_rpc_client.adc
-	edgepi_rpc_client.dac
-	edgepi_rpc_client.din
-	edgepi_rpc_client.dout
-	edgepi_rpc_client.led
-	edgepi_rpc_client.relay
-	edgepi_rpc_client.tc
+package_dir=
+    =edgepi_rpc_client/services
+packages=find:
+
+[options.packages.find]
+where=edgepi_rpc_client/services
 install_requires = 
 	protobuf>=3.20.3
 	edgepi-rpc-protobuf>=1.0.15
-	python-periphery>=2.4.1
 	pyzmq>=25.1.0
-	edgepi-python-sdk>=1.2.6
+	edgepi-python-sdk>=1.2.13


### PR DESCRIPTION
Changed the `packages` field in setup.cfg to use `find:` instead of listing each module individually. The `edgepi_rpc_server` folder has a lot of modules now so I feel this would be less error-prone.