### PR TITLE
Fix version.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,3 +1,3 @@
 [bumpversion]
 tag_name = rc/v{new_version}
-current_version = 0.0.10
+current_version = 0.0.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = edgepi-rpc-client
-version = 0.0.10
+version = 0.0.9
 author = Josiah Kievit, Isaac James
 author_email = jkievit@osensa.com, ijames@osensa.com
 description = Client for EdgePi RPC Server


### PR DESCRIPTION
When the last 2 builds failed, the version was bumped without actually building the module. Reverting the version in the staging branch to match the actual version.