### PR TITLE
Revert workflow.

### DIFF
--- a/.github/workflows/build-publish-pypi-test.yml
+++ b/.github/workflows/build-publish-pypi-test.yml
@@ -17,18 +17,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
       with:
-        persist-credentials: false
-    - name: Set up Python
-      uses: actions/setup-python@v3
-      with:
-        python-version: '3.10'
-    - name: Install Dependencies
-      run: |
-        python -m pip install --upgrade pip
-        if [ -f requirements_build.txt ]; then python -m pip install -r requirements_build.txt; fi
-    - name: Build Package # Build before getting current version in case build fails
-      run: |
-        python -m build
+          persist-credentials: false
     - name: Get Current Version
       run: echo -n "current_version=$(grep "version" setup.cfg | cut -d '=' -f2 | tr -d ' \t\n\r')" >> $GITHUB_ENV
     - name: Auto Bump Package Version
@@ -41,6 +30,14 @@ jobs:
         commit_email: bot@edgepi.com
         login: bot-edgepi
         token: "${{ secrets.ACTIONS_BOT_TOKEN }}"
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.10'
+    - name: Install Dependencies
+      run: |
+        python -m pip install --upgrade pip
+        if [ -f requirements_build.txt ]; then python -m pip install -r requirements_build.txt; fi
     - name: Build Package
       run: |
         python -m build


### PR DESCRIPTION
The previously updated workflow (with the build happening before the auto bump) caused an error. I'm reverting to the previous workflow until I finish setting up the client/ server setup. I can update the workflow in a separate PR later on.