### PR TITLE
Fix packaging error.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,14 +13,7 @@ classifiers =
 
 [options]
 packages =
-	edgepi_rpc_client
-	edgepi_rpc_client.services.adc
-	edgepi_rpc_client.services.dac
-	edgepi_rpc_client.services.din
-	edgepi_rpc_client.services.dout
-	edgepi_rpc_client.services.led
-	edgepi_rpc_client.services.relay
-	edgepi_rpc_client.services.tc
+	find:
 
 install_requires = 
 	protobuf>=3.20.3


### PR DESCRIPTION
Updated `setup.cfg` to include locally imported modules in the build. Fixes `ModuleNotFound` errors occuring when installing the package from the edgpi-rpc-server repo.