### PR TITLE
Fix packaging error.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,14 +13,7 @@ classifiers =
 
 [options]
 packages =
-	edgepi_rpc_client
-	edgepi_rpc_client.services.adc
-	edgepi_rpc_client.services.dac
-	edgepi_rpc_client.services.din
-	edgepi_rpc_client.services.dout
-	edgepi_rpc_client.services.led
-	edgepi_rpc_client.services.relay
-	edgepi_rpc_client.services.tc
+	find:
 
 install_requires = 
 	protobuf>=3.20.3

--- a/tests/integration/test_module.py
+++ b/tests/integration/test_module.py
@@ -1,9 +1,11 @@
-"""Client Build Integration Test"""
 import subprocess
 import os
+import pytest
+from tempfile import TemporaryDirectory
 
 def test_rpc_client_install():
     """Test client import"""
+    
     # Build the wheel
     subprocess.check_call(["pip3", "install", "build"])
     subprocess.check_call(["python", "-m", "build"])
@@ -12,10 +14,18 @@ def test_rpc_client_install():
     wheel_file = next((file for file in os.listdir("dist") if file.endswith(".whl")), None)
     assert wheel_file, "Wheel file not found"
 
-    # Install the wheel
-    subprocess.check_call(["pip3", "install", os.path.join("dist", wheel_file)])
+    with TemporaryDirectory() as tempdir:
+        # Install the wheel inside temp directory
+        subprocess.check_call(["pip3", "install", os.path.join("dist", wheel_file), "--target", tempdir])
 
-    # Check imports
-    # pylint: disable=import-outside-toplevel, unused-import
-    from edgepi_rpc_client.services.led.client_led_service import ClientLEDService
-    from edgepi_rpc_client.services.led.led_pb_enums import LEDPins
+        # Add the temporary directory to sys.path so that we can import from there
+        import sys
+        sys.path.insert(0, tempdir)
+
+        # Check imports
+        # pylint: disable=import-outside-toplevel, unused-import
+        from edgepi_rpc_client.services.led.client_led_service import ClientLEDService
+        from edgepi_rpc_client.services.led.led_pb_enums import LEDPins
+
+        # Clean up sys.path
+        sys.path.remove(tempdir)


### PR DESCRIPTION
Updated setup.cfg to include locally imported modules in the build. Fixes ModuleNotFound errors occuring when installing the package from the edgpi-rpc-server repo.

This is a repeat of a previous PR. Repeating as dev is now aligned with staging.