### PR TITLE
Add a service for the PWM module

### DIFF
--- a/edgepi_rpc_client/services/pwm/client_pwm_service.py
+++ b/edgepi_rpc_client/services/pwm/client_pwm_service.py
@@ -19,45 +19,15 @@ class ClientPWMService():
 
     def set_config(self, pwm_num: PWMPins,
                    frequency: float = None,
-                   duty_cycle: int = None,
+                   duty_cycle: float = None,
                    polarity: Polarity = None):
         """set_config method for SDK PWM module"""
-        config_args_dict= filter_arg_values(locals(), 'self', None)
+        config_args_dict = filter_arg_values(locals(), 'self', None)
         config_msg = pwm_pb.Config()
         arg_msg = pwm_pb.Config().ConfArg()
 
         request = create_config_request_from_args(config_msg, arg_msg, config_args_dict)
         rpc_response = self.service_stub.set_config(self.rpc_controller,request)
-        response = get_server_response(rpc_response, pwm_pb.SuccessMsg)
-        return response.content
-
-    def set_frequency(self, pwm_num: PWMPins, frequency: float):
-        """set_frequency method for SDK PWM module"""
-        request = pwm_pb.SetFrequency(
-            pwm_num = pwm_num.value,
-            frequency = frequency
-        )
-        rpc_response = self.service_stub.set_frequency(self.rpc_controller, request)
-        response = get_server_response(rpc_response, pwm_pb.SuccessMsg)
-        return response.content
-
-    def set_duty_cycle(self, pwm_num: PWMPins, duty_cycle: float):
-        """set_duty_cycle method for SDK PWM module"""
-        request = pwm_pb.SetDutyCycle(
-            pwm_num = pwm_num.value,
-            duty_cycle = duty_cycle
-        )
-        rpc_response = self.service_stub.set_duty_cycle(self.rpc_controller, request)
-        response = get_server_response(rpc_response, pwm_pb.SuccessMsg)
-        return response.content
-
-    def set_polarity(self, pwm_num: PWMPins, polarity: Polarity):
-        """set_polarity method for SDK PWM module"""
-        request = pwm_pb.SetPolarity(
-            pwm_num = pwm_num.value,
-            polarity = polarity.value
-        )
-        rpc_response = self.service_stub.set_polarity(self.rpc_controller, request)
         response = get_server_response(rpc_response, pwm_pb.SuccessMsg)
         return response.content
 
@@ -93,28 +63,27 @@ class ClientPWMService():
         """get_frequency method for SDK PWM module"""
         request = pwm_pb.PWM(pwm_num = pwm_num.value)
         rpc_response = self.service_stub.get_frequency(self.rpc_controller, request)
-        response = get_server_response(rpc_response, pwm_pb.Frequency)
-        return response.content
+        response = get_server_response(rpc_response, pwm_pb.GetFrequency)
+        return response.frequency
 
     def get_duty_cycle(self, pwm_num: PWMPins):
         """get_duty_cycle method for SDK PWM module"""
         request = pwm_pb.PWM(pwm_num = pwm_num.value)
         rpc_response = self.service_stub.get_duty_cycle(self.rpc_controller, request)
-        response = get_server_response(rpc_response, pwm_pb.DutyCycle)
-        return response.content
+        response = get_server_response(rpc_response, pwm_pb.GetDutyCycle)
+        return response.duty_cycle
 
     def get_polarity(self, pwm_num: PWMPins):
         """get_polarity method for SDK PWM module"""
         request = pwm_pb.PWM(pwm_num = pwm_num.value)
+        
         rpc_response = self.service_stub.get_polarity(self.rpc_controller, request)
-        response = get_server_response(rpc_response, pwm_pb.Polarity)
-        return response.content
+        response = get_server_response(rpc_response, pwm_pb.GetPolarity)
+        return Polarity(response.polarity)
 
     def get_enabled(self, pwm_num: PWMPins):
         """get_enabled method for SDK PWM module"""
         request = pwm_pb.PWM(pwm_num = pwm_num.value)
         rpc_response = self.service_stub.get_enabled(self.rpc_controller, request)
-        response = get_server_response(rpc_response, pwm_pb.Enabled)
-        return response.content
-
-#NOTE: change response.content to appropriate return values
+        response = get_server_response(rpc_response, pwm_pb.GetEnabled)
+        return response.enabled

--- a/edgepi_rpc_client/services/pwm/client_pwm_service.py
+++ b/edgepi_rpc_client/services/pwm/client_pwm_service.py
@@ -1,0 +1,120 @@
+"""Client for PWM service"""
+import logging
+from edgepirpc.protos import pwm_pb2 as pwm_pb
+from edgepi_rpc_client.client_rpc_channel import ClientRpcChannel
+from edgepi_rpc_client.util.helpers import (
+    filter_arg_values, create_config_request_from_args, get_server_response
+)
+from edgepi_rpc_client.services.pwm.pwm_pb_enums import PWMPins, Polarity
+
+_logger = logging.getLogger(__name__)
+
+# pylint: disable=no-member
+class ClientPWMService():
+    """Client Methods for PWM Service"""
+    def __init__(self, transport):
+        self.client_rpc_channel = ClientRpcChannel(transport)
+        self.service_stub = pwm_pb.PWMService_Stub(self.client_rpc_channel)
+        self.rpc_controller = None
+
+    def set_config(self, pwm_num: PWMPins,
+                   frequency: float = None,
+                   duty_cycle: int = None,
+                   polarity: Polarity = None):
+        """set_config method for SDK PWM module"""
+        config_args_dict= filter_arg_values(locals(), 'self', None)
+        config_msg = pwm_pb.Config()
+        arg_msg = pwm_pb.Config().ConfArg()
+
+        request = create_config_request_from_args(config_msg, arg_msg, config_args_dict)
+        rpc_response = self.service_stub.set_config(self.rpc_controller,request)
+        response = get_server_response(rpc_response, pwm_pb.SuccessMsg)
+        return response.content
+
+    def set_frequency(self, pwm_num: PWMPins, frequency: float):
+        """set_frequency method for SDK PWM module"""
+        request = pwm_pb.SetFrequency(
+            pwm_num = pwm_num.value,
+            frequency = frequency
+        )
+        rpc_response = self.service_stub.set_frequency(self.rpc_controller, request)
+        response = get_server_response(rpc_response, pwm_pb.SuccessMsg)
+        return response.content
+
+    def set_duty_cycle(self, pwm_num: PWMPins, duty_cycle: float):
+        """set_duty_cycle method for SDK PWM module"""
+        request = pwm_pb.SetDutyCycle(
+            pwm_num = pwm_num.value,
+            duty_cycle = duty_cycle
+        )
+        rpc_response = self.service_stub.set_duty_cycle(self.rpc_controller, request)
+        response = get_server_response(rpc_response, pwm_pb.SuccessMsg)
+        return response.content
+
+    def set_polarity(self, pwm_num: PWMPins, polarity: Polarity):
+        """set_polarity method for SDK PWM module"""
+        request = pwm_pb.SetPolarity(
+            pwm_num = pwm_num.value,
+            polarity = polarity.value
+        )
+        rpc_response = self.service_stub.set_polarity(self.rpc_controller, request)
+        response = get_server_response(rpc_response, pwm_pb.SuccessMsg)
+        return response.content
+
+    def enable(self, pwm_num: PWMPins):
+        """enable method for SDK PWM module"""
+        request = pwm_pb.PWM(pwm_num = pwm_num.value)
+        rpc_response = self.service_stub.enable(self.rpc_controller, request)
+        response = get_server_response(rpc_response, pwm_pb.SuccessMsg)
+        return response.content
+
+    def disable(self, pwm_num: PWMPins):
+        """disable method for SDK PWM module"""
+        request = pwm_pb.PWM(pwm_num = pwm_num.value)
+        rpc_response = self.service_stub.disable(self.rpc_controller, request)
+        response = get_server_response(rpc_response, pwm_pb.SuccessMsg)
+        return response.content
+
+    def close(self, pwm_num: PWMPins):
+        """close method for SDK PWM module"""
+        request = pwm_pb.PWM(pwm_num = pwm_num.value)
+        rpc_response = self.service_stub.close(self.rpc_controller, request)
+        response = get_server_response(rpc_response, pwm_pb.SuccessMsg)
+        return response.content
+
+    def init_pwm(self, pwm_num: PWMPins):
+        """init_pwm method for SDK PWM module"""
+        request = pwm_pb.PWM(pwm_num = pwm_num.value)
+        rpc_response = self.service_stub.init_pwm(self.rpc_controller, request)
+        response = get_server_response(rpc_response, pwm_pb.SuccessMsg)
+        return response.content
+
+    def get_frequency(self, pwm_num: PWMPins):
+        """get_frequency method for SDK PWM module"""
+        request = pwm_pb.PWM(pwm_num = pwm_num.value)
+        rpc_response = self.service_stub.get_frequency(self.rpc_controller, request)
+        response = get_server_response(rpc_response, pwm_pb.Frequency)
+        return response.content
+
+    def get_duty_cycle(self, pwm_num: PWMPins):
+        """get_duty_cycle method for SDK PWM module"""
+        request = pwm_pb.PWM(pwm_num = pwm_num.value)
+        rpc_response = self.service_stub.get_duty_cycle(self.rpc_controller, request)
+        response = get_server_response(rpc_response, pwm_pb.DutyCycle)
+        return response.content
+
+    def get_polarity(self, pwm_num: PWMPins):
+        """get_polarity method for SDK PWM module"""
+        request = pwm_pb.PWM(pwm_num = pwm_num.value)
+        rpc_response = self.service_stub.get_polarity(self.rpc_controller, request)
+        response = get_server_response(rpc_response, pwm_pb.Polarity)
+        return response.content
+
+    def get_enabled(self, pwm_num: PWMPins):
+        """get_enabled method for SDK PWM module"""
+        request = pwm_pb.PWM(pwm_num = pwm_num.value)
+        rpc_response = self.service_stub.get_enabled(self.rpc_controller, request)
+        response = get_server_response(rpc_response, pwm_pb.Enabled)
+        return response.content
+
+#NOTE: change response.content to appropriate return values

--- a/edgepi_rpc_client/services/pwm/client_pwm_service.py
+++ b/edgepi_rpc_client/services/pwm/client_pwm_service.py
@@ -21,8 +21,6 @@ class ClientPWMService:
         self.service_stub = pwm_pb.PWMService_Stub(self.client_rpc_channel)
         self.rpc_controller = None
 
-    
-
     # pylint: disable=unused-argument
     def set_config(
         self,
@@ -36,65 +34,66 @@ class ClientPWMService:
         config_msg = pwm_pb.Config()
         arg_msg = pwm_pb.Config().ConfArg()
         request = create_config_request_from_args(config_msg, arg_msg, config_args_dict)
-        return self.perform_call_from_request(request, self.service_stub.set_config, pwm_pb.SuccessMsg)
+        return self.perform_call_from_request(
+            request, self.service_stub.set_config, pwm_pb.SuccessMsg
+        ).content
 
     def enable(self, pwm_num: PWMPins):
         """enable method for SDK PWM module"""
         return self.perform_rpc_call(
             pwm_num, self.service_stub.enable, pwm_pb.SuccessMsg
-        )
+        ).content
 
     def disable(self, pwm_num: PWMPins):
         """disable method for SDK PWM module"""
         return self.perform_rpc_call(
             pwm_num, self.service_stub.disable, pwm_pb.SuccessMsg
-        )
+        ).content
 
     def close(self, pwm_num: PWMPins):
         """close method for SDK PWM module"""
         return self.perform_rpc_call(
             pwm_num, self.service_stub.close, pwm_pb.SuccessMsg
-        )
+        ).content
 
     def init_pwm(self, pwm_num: PWMPins):
         """init_pwm method for SDK PWM module"""
         return self.perform_rpc_call(
             pwm_num, self.service_stub.init_pwm, pwm_pb.SuccessMsg
-        )
+        ).content
 
     def get_frequency(self, pwm_num: PWMPins):
         """get_frequency method for SDK PWM module"""
         return self.perform_rpc_call(
-            pwm_num, self.service_stub.get_frequency, pwm_pb.GetFrequency, "frequency"
-        )
+            pwm_num, self.service_stub.get_frequency, pwm_pb.GetFrequency
+        ).frequency
 
     def get_duty_cycle(self, pwm_num: PWMPins):
         """get_duty_cycle method for SDK PWM module"""
         return self.perform_rpc_call(
-            pwm_num, self.service_stub.get_duty_cycle, pwm_pb.GetDutyCycle, "duty_cycle"
-        )
+            pwm_num, self.service_stub.get_duty_cycle, pwm_pb.GetDutyCycle
+        ).duty_cycle
 
     def get_polarity(self, pwm_num: PWMPins):
         """get_polarity method for SDK PWM module"""
         polarity = self.perform_rpc_call(
-            pwm_num, self.service_stub.get_polarity, pwm_pb.GetPolarity, "polarity"
-        )
+            pwm_num, self.service_stub.get_polarity, pwm_pb.GetPolarity
+        ).polarity
         return Polarity(polarity)
 
     def get_enabled(self, pwm_num: PWMPins):
         """get_enabled method for SDK PWM module"""
         return self.perform_rpc_call(
-            pwm_num, self.service_stub.get_enabled, pwm_pb.GetEnabled, "enabled"
-        )
+            pwm_num, self.service_stub.get_enabled, pwm_pb.GetEnabled
+        ).enabled
 
     # TODO: Potentially these helpers in other services and put them in a separate file
-    def perform_rpc_call(self, pwm_num, method, response_type, return_attr=None):
+    def perform_rpc_call(self, pwm_num, method, response_type):
         """Performs RPC call with PWM number and specified method"""
         request = pwm_pb.PWM(pwm_num=pwm_num.value)
-        return self.perform_call_from_request(request, method, response_type, return_attr)
+        return self.perform_call_from_request(request, method, response_type)
 
-    def perform_call_from_request(self, request, method, response_type, return_attr=None):
+    def perform_call_from_request(self, request, method, response_type):
         """Executes RPC call using provided request and method"""
         rpc_response = method(self.rpc_controller, request)
-        response = get_server_response(rpc_response, response_type)
-        return getattr(response, return_attr) if return_attr else response.content
+        return get_server_response(rpc_response, response_type)

--- a/edgepi_rpc_client/services/pwm/client_pwm_service.py
+++ b/edgepi_rpc_client/services/pwm/client_pwm_service.py
@@ -3,88 +3,98 @@ import logging
 from edgepirpc.protos import pwm_pb2 as pwm_pb
 from edgepi_rpc_client.client_rpc_channel import ClientRpcChannel
 from edgepi_rpc_client.util.helpers import (
-    filter_arg_values, create_config_request_from_args, get_server_response
+    filter_arg_values,
+    create_config_request_from_args,
+    get_server_response,
 )
 from edgepi_rpc_client.services.pwm.pwm_pb_enums import PWMPins, Polarity
 
 _logger = logging.getLogger(__name__)
 
+
 # pylint: disable=no-member
-class ClientPWMService():
+class ClientPWMService:
     """Client Methods for PWM Service"""
+
     def __init__(self, transport):
         self.client_rpc_channel = ClientRpcChannel(transport)
         self.service_stub = pwm_pb.PWMService_Stub(self.client_rpc_channel)
         self.rpc_controller = None
 
+    
+
     # pylint: disable=unused-argument
-    def set_config(self, pwm_num: PWMPins,
-                   frequency: float = None,
-                   duty_cycle: float = None,
-                   polarity: Polarity = None):
+    def set_config(
+        self,
+        pwm_num: PWMPins,
+        frequency: float = None,
+        duty_cycle: float = None,
+        polarity: Polarity = None,
+    ):
         """set_config method for SDK PWM module"""
-        config_args_dict = filter_arg_values(locals(), 'self', None)
+        config_args_dict = filter_arg_values(locals(), "self", None)
         config_msg = pwm_pb.Config()
         arg_msg = pwm_pb.Config().ConfArg()
-
         request = create_config_request_from_args(config_msg, arg_msg, config_args_dict)
-        rpc_response = self.service_stub.set_config(self.rpc_controller,request)
-        response = get_server_response(rpc_response, pwm_pb.SuccessMsg)
-        return response.content
+        return self.perform_call_from_request(request, self.service_stub.set_config, pwm_pb.SuccessMsg)
 
     def enable(self, pwm_num: PWMPins):
         """enable method for SDK PWM module"""
-        request = pwm_pb.PWM(pwm_num = pwm_num.value)
-        rpc_response = self.service_stub.enable(self.rpc_controller, request)
-        response = get_server_response(rpc_response, pwm_pb.SuccessMsg)
-        return response.content
+        return self.perform_rpc_call(
+            pwm_num, self.service_stub.enable, pwm_pb.SuccessMsg
+        )
 
     def disable(self, pwm_num: PWMPins):
         """disable method for SDK PWM module"""
-        request = pwm_pb.PWM(pwm_num = pwm_num.value)
-        rpc_response = self.service_stub.disable(self.rpc_controller, request)
-        response = get_server_response(rpc_response, pwm_pb.SuccessMsg)
-        return response.content
+        return self.perform_rpc_call(
+            pwm_num, self.service_stub.disable, pwm_pb.SuccessMsg
+        )
 
     def close(self, pwm_num: PWMPins):
         """close method for SDK PWM module"""
-        request = pwm_pb.PWM(pwm_num = pwm_num.value)
-        rpc_response = self.service_stub.close(self.rpc_controller, request)
-        response = get_server_response(rpc_response, pwm_pb.SuccessMsg)
-        return response.content
+        return self.perform_rpc_call(
+            pwm_num, self.service_stub.close, pwm_pb.SuccessMsg
+        )
 
     def init_pwm(self, pwm_num: PWMPins):
         """init_pwm method for SDK PWM module"""
-        request = pwm_pb.PWM(pwm_num = pwm_num.value)
-        rpc_response = self.service_stub.init_pwm(self.rpc_controller, request)
-        response = get_server_response(rpc_response, pwm_pb.SuccessMsg)
-        return response.content
+        return self.perform_rpc_call(
+            pwm_num, self.service_stub.init_pwm, pwm_pb.SuccessMsg
+        )
 
     def get_frequency(self, pwm_num: PWMPins):
         """get_frequency method for SDK PWM module"""
-        request = pwm_pb.PWM(pwm_num = pwm_num.value)
-        rpc_response = self.service_stub.get_frequency(self.rpc_controller, request)
-        response = get_server_response(rpc_response, pwm_pb.GetFrequency)
-        return response.frequency
+        return self.perform_rpc_call(
+            pwm_num, self.service_stub.get_frequency, pwm_pb.GetFrequency, "frequency"
+        )
 
     def get_duty_cycle(self, pwm_num: PWMPins):
         """get_duty_cycle method for SDK PWM module"""
-        request = pwm_pb.PWM(pwm_num = pwm_num.value)
-        rpc_response = self.service_stub.get_duty_cycle(self.rpc_controller, request)
-        response = get_server_response(rpc_response, pwm_pb.GetDutyCycle)
-        return response.duty_cycle
+        return self.perform_rpc_call(
+            pwm_num, self.service_stub.get_duty_cycle, pwm_pb.GetDutyCycle, "duty_cycle"
+        )
 
     def get_polarity(self, pwm_num: PWMPins):
         """get_polarity method for SDK PWM module"""
-        request = pwm_pb.PWM(pwm_num = pwm_num.value)
-
-        rpc_response = self.service_stub.get_polarity(self.rpc_controller, request)
-        response = get_server_response(rpc_response, pwm_pb.GetPolarity)
-        return Polarity(response.polarity)
+        polarity = self.perform_rpc_call(
+            pwm_num, self.service_stub.get_polarity, pwm_pb.GetPolarity, "polarity"
+        )
+        return Polarity(polarity)
 
     def get_enabled(self, pwm_num: PWMPins):
         """get_enabled method for SDK PWM module"""
-        request = pwm_pb.PWM(pwm_num = pwm_num.value)
-        rpc_response = self.service_stub.get_enabled(self.rpc_controller, request)
-        response = get_server_response(rpc_response, pwm_pb.GetEnabled)
-        return response.enabled
+        return self.perform_rpc_call(
+            pwm_num, self.service_stub.get_enabled, pwm_pb.GetEnabled, "enabled"
+        )
+
+    # TODO: Potentially these helpers in other services and put them in a separate file
+    def perform_rpc_call(self, pwm_num, method, response_type, return_attr=None):
+        """Performs RPC call with PWM number and specified method"""
+        request = pwm_pb.PWM(pwm_num=pwm_num.value)
+        return self.perform_call_from_request(request, method, response_type, return_attr)
+
+    def perform_call_from_request(self, request, method, response_type, return_attr=None):
+        """Executes RPC call using provided request and method"""
+        rpc_response = method(self.rpc_controller, request)
+        response = get_server_response(rpc_response, response_type)
+        return getattr(response, return_attr) if return_attr else response.content

--- a/edgepi_rpc_client/services/pwm/client_pwm_service.py
+++ b/edgepi_rpc_client/services/pwm/client_pwm_service.py
@@ -17,6 +17,7 @@ class ClientPWMService():
         self.service_stub = pwm_pb.PWMService_Stub(self.client_rpc_channel)
         self.rpc_controller = None
 
+    # pylint: disable=unused-argument
     def set_config(self, pwm_num: PWMPins,
                    frequency: float = None,
                    duty_cycle: float = None,
@@ -76,7 +77,7 @@ class ClientPWMService():
     def get_polarity(self, pwm_num: PWMPins):
         """get_polarity method for SDK PWM module"""
         request = pwm_pb.PWM(pwm_num = pwm_num.value)
-        
+
         rpc_response = self.service_stub.get_polarity(self.rpc_controller, request)
         response = get_server_response(rpc_response, pwm_pb.GetPolarity)
         return Polarity(response.polarity)

--- a/edgepi_rpc_client/services/pwm/pwm_pb_enums.py
+++ b/edgepi_rpc_client/services/pwm/pwm_pb_enums.py
@@ -1,0 +1,13 @@
+"""Client enums to protobuf PWM enums"""
+from enum import Enum
+from edgepirpc.protos import pwm_pb2 as pwm_pb
+
+class PWMPins(Enum):
+    """PWMPins Enum"""
+    PWM1 = pwm_pb.PWMPins.PWM1: PWMPins.PWM1
+    PWM2 = pwm_pb.PWMPins.PWM2: PWMPins.PWM2
+
+class Polarity(Enum):
+    """Polarity Enum"""
+    NORMAL = pwm_pb.Polarity.NORMAL
+    INVERSED = pwm_pb.Polarity.INVERSED

--- a/edgepi_rpc_client/services/pwm/pwm_pb_enums.py
+++ b/edgepi_rpc_client/services/pwm/pwm_pb_enums.py
@@ -4,8 +4,8 @@ from edgepirpc.protos import pwm_pb2 as pwm_pb
 
 class PWMPins(Enum):
     """PWMPins Enum"""
-    PWM1 = pwm_pb.PWMPins.PWM1: PWMPins.PWM1
-    PWM2 = pwm_pb.PWMPins.PWM2: PWMPins.PWM2
+    PWM1 = pwm_pb.PWMPins.PWM1
+    PWM2 = pwm_pb.PWMPins.PWM2
 
 class Polarity(Enum):
     """Polarity Enum"""

--- a/tests/integration/test_pwm_service.py
+++ b/tests/integration/test_pwm_service.py
@@ -1,0 +1,154 @@
+"""PWMService integration test"""
+import pytest
+from edgepi_rpc_client.services.pwm.client_pwm_service import ClientPWMService
+from edgepi_rpc_client.services.pwm.pwm_pb_enums import PWMPins, Polarity
+
+@pytest.fixture(name="pwm_service")
+def fixture_test_pwm_service():
+    """Inits new PWM service client for testing"""
+    return ClientPWMService('tcp://localhost:4444')
+
+@pytest.mark.parametrize(
+    "pwm_num",
+    [
+        (PWMPins.PWM1),
+        (PWMPins.PWM2),
+    ]
+)
+def test_set_config(pwm_service, pwm_num):
+    """Test for set_config"""
+    response_init = pwm_service.init_pwm(pwm_num)
+    assert response_init == "Successfully intialized PWM"
+    response_config = pwm_service.set_config(pwm_num)
+    assert response_config == "Successfully applied pwm configurations"
+
+@pytest.mark.parametrize(
+    "pwm_num, frequency",
+    [
+        (PWMPins.PWM1, 1000),
+        (PWMPins.PWM1, 10000),
+    ]
+)
+def test_set_frequency(pwm_service, pwm_num, frequency):
+    """Test for set_frequency"""
+    pwm_service.init_pwm(pwm_num)
+    response = pwm_service.set_frequency(pwm_num, frequency)
+    assert response == "Successfully set PWM frequency"
+
+@pytest.mark.parametrize(
+    "pwm_num, duty_cycle",
+    [
+        (PWMPins.PWM1, 0),
+        (PWMPins.PWM1, 100),
+    ]
+)
+def test_set_duty_cycle(pwm_service, pwm_num, duty_cycle):
+    """Test for set_duty_cycle"""
+    pwm_service.init_pwm(pwm_num)
+    response = pwm_service.set_duty_cycle(pwm_num, duty_cycle)
+    assert response == "Successfully set PWM duty cycle"
+
+@pytest.mark.parametrize(
+    "pwm_num, polarity",
+    [
+        (PWMPins.PWM1, Polarity.NORMAL),
+        (PWMPins.PWM1, Polarity.INVERSED),
+    ]
+)
+def test_set_polarity(pwm_service, pwm_num, polarity):
+    """Test for set_polarity"""
+    pwm_service.init_pwm(pwm_num)
+    response = pwm_service.set_polarity(pwm_num, polarity)
+    assert response == "Successfully set PWM polarity"
+
+@pytest.mark.parametrize(
+    'pwm_num',
+    [
+        (PWMPins.PWM1),
+        (PWMPins.PWM2),
+    ]
+)
+def test_enable(pwm_service, pwm_num):
+    """Test for set_enable"""
+    pwm_service.init_pwm(pwm_num)
+    response = pwm_service.enable(pwm_num)
+    assert response == "Successfully enabled PWM"
+
+@pytest.mark.parametrize(
+    'pwm_num',
+    [
+        (PWMPins.PWM1),
+        (PWMPins.PWM2),
+    ]
+)
+def test_disable(pwm_service, pwm_num):
+    """Test for set_disable"""
+    pwm_service.init_pwm(pwm_num)
+    response = pwm_service.disable(pwm_num)
+    assert response == "Successfully disabled PWM"
+
+@pytest.mark.parametrize(
+    'pwm_num',
+    [
+        (PWMPins.PWM1),
+        (PWMPins.PWM2),
+    ]
+)
+def test_close(pwm_service, pwm_num):
+    """Test for close"""
+    pwm_service.init_pwm(pwm_num)
+    response = pwm_service.close(pwm_num)
+    assert response == "Successfully closed PWM"
+
+
+@pytest.mark.parametrize(
+    'pwm_num',
+    [
+        (PWMPins.PWM1),
+        (PWMPins.PWM2),
+    ]
+)
+def test_get_frequency(pwm_service, pwm_num):
+    """Test for get_frequency"""
+    pwm_service.init_pwm(pwm_num)
+    frequency = pwm_service.get_frequency(pwm_num)
+    assert isinstance(frequency, float)
+
+@pytest.mark.parametrize(
+    'pwm_num',
+    [
+        (PWMPins.PWM1),
+        (PWMPins.PWM2),
+    ]
+)
+def test_get_duty_cycle(pwm_service, pwm_num):
+    """Test for get_duty_cycle"""
+    pwm_service.init_pwm(pwm_num)
+    duty_cycle = pwm_service.get_duty_cycle(pwm_num)
+    assert isinstance(duty_cycle, int)
+
+@pytest.mark.parametrize(
+    'pwm_num',
+    [
+        (PWMPins.PWM1),
+        (PWMPins.PWM2),
+    ]
+)
+def test_get_polarity(pwm_service, pwm_num):
+    """Test for get_polarity"""
+    pwm_service.init_pwm(pwm_num)
+    polarity = pwm_service.get_polarity(pwm_num)
+    assert polarity in Polarity
+
+@pytest.mark.parametrize(
+    'pwm_num',
+    [
+        (PWMPins.PWM1),
+        (PWMPins.PWM2),
+    ]
+)
+def test_get_enabled(pwm_service, pwm_num):
+    """Test for get_enabled"""
+    pwm_service.init_pwm(pwm_num)
+    enabled = pwm_service.get_enabled(pwm_num)
+    assert isinstance(enabled, bool)


### PR DESCRIPTION
Added a client RPC service for the PWM module on the EdgePi.

Included implementation for the following functions on the SDK: `init_pwm, set_config, enable, disable, close, get_frequency, get_duty_cycle, get_polarity, get_enabled.`


Included integration tests to test functionality of the RPC client and the complementary server service.

NOTE: pylint tests are failing because the protobuf pr hasn't merged yet.